### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is an example of how to use this action. If the event trigger is not for an
 name: Assigned Issues Are In Progress
 
 on:
-  issue:
+  issues:
     types: [assigned]
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 	  - name: Move to In Progress
-	    uses: kin/gh-action-move-issue-to-column@1.0
+	    uses: kin/gh-action-move-issues-to-column@v1.0
 		with:
 		  access-token: "#{{ secrets.GITHUB_TOKEN }}"
 		  project-name: "My Project"
@@ -28,11 +28,11 @@ jobs:
 ## Inputs
 ### Required
 - `access-token`: Access token for repository. Use `"{{ secrets.GITHUB_TOKEN }}"` to prevent leaking secrets. This may require setting up a token with increased privileges. The token must have `repo` privileges.
-- `project-name`: Case-insensitive string matching name of the existing project the target column is in
+- `project-name`: Case-insensitive string matching name of the existing project the target column is in.
 - `target-column`: Case-insensitive string matching the name of the existing column the cards should be moved to.
 
 ### Optional
-- `issues`: A stringified array of Github [issue payloads](https://docs.github.com/en/free-pro-team@latest/rest/reference/issues#get-an-issue) formatted `[{ issue: { <webhook payload for issue } }, ...]`. Only needs to be used if the workflow event triggers are not of the `issue` type.
+- `issues`: A stringified array of Github [issue payloads](https://docs.github.com/en/free-pro-team@latest/rest/reference/issues#get-an-issue) formatted `[{ issue: { <webhook payload for issue } }, ...]`. Only needs to be used if the workflow event triggers are not of the `issues` type.
 
 ## Contribution
-To cotnribute, please open an Issue on the action repo: https://github.com/kin/gh-action-autoarchive-issues-for-column to discuss bugs/modifications.
+To contribute, please open an Issue on the action repo: https://github.com/kin/gh-action-autoarchive-issues-for-column to discuss bugs/modifications.


### PR DESCRIPTION
These typos, especially the ones in the action name, took _way_ too long to catch.
Kudos to @simon-wolf for finding these.